### PR TITLE
ref:`drawCard`の責任範囲を分割するため、`makeDeck`関数とテストコードを追加

### DIFF
--- a/src/lib/black_jack/Deck.php
+++ b/src/lib/black_jack/Deck.php
@@ -8,18 +8,28 @@ require_once(__DIR__.'/Card.php');
 
 class Deck
 {
+    public function __construct(public Card $card)
+    {
+    }
+
+    // TODO 山札作成（シャフルまで）
+    public function makeDeck()
+    {
+        // 52枚のカードを持つ配列のプロパティを初期設定
+        // カードをシャッフル処理
+        shuffle($this->card->cards);
+        return $this->card->cards;
+    }
+
+    // 人数分のデッキを作成
     // TODO:人数増加に対応させる
     public function drawCard()
     {
         $playerCards = [];
-
-        // 52枚のカードを持つ配列のプロパティを初期設定
-        $card = new Card;
-        // カードをシャッフル処理
-        shuffle($card->cards);
         // ディーラー含む２名分のカード４枚をスライス
         // カードを手札用に2枚単位で分割してプレイヤー２名分のカードを準備
-        $playerCards = array_chunk(array_slice($card->cards, 0, 4), 2);
+
+        $playerCards = array_chunk(array_slice($this->makeDeck(), 0, 4), 2);
         return $playerCards;
     }
 }

--- a/src/tests/black_jack/DeckTest.php
+++ b/src/tests/black_jack/DeckTest.php
@@ -4,14 +4,25 @@ namespace BlackJack\Tests;
 
 use PHPUnit\Framework\TestCase;
 use BlackJack\Deck;
+use BlackJack\Card;
 
 require_once(__DIR__ . '/../../lib/black_jack/Deck.php');
+require_once(__DIR__ . '/../../lib/black_jack/Card.php');
 
 class DeckTest extends TestCase
 {
+    public function testMakeDeck()
+    {
+        $deck = new Deck(new Card);
+        $shuffledDeck = $deck->makeDeck();
+        $this->assertSame(52, count($shuffledDeck));
+        $this->assertSame(count($shuffledDeck), count(array_unique($shuffledDeck)));
+        $this->assertEqualsCanonicalizing($deck->card->cards, $shuffledDeck);
+    }
+
     public function testDrawCard()
     {
-        $deck = new Deck;
+        $deck = new Deck(new Card);
         $playerCards = $deck->drawCard();
 
         // 型の確認


### PR DESCRIPTION
### プルリクエスト概要
- `makeDeck` 関数を作成し、`Card` クラスからシャッフル済みの山札を生成
- 山札の生成とシャッフルを確認するテストを追加

### 変更内容
1. `Deck.php`
    - 依存性注入を導入し、疎結合化
    - `drawCard()` 内で `makeDeck()` を呼び出すよう変更
     
2. `DeckTest.php`
    - 山札生成とシャッフル処理を確認するテストを追加

### 確認事項
- [X] コードが意図通りに動作している
- [X] 必要なテストが追加または更新されている

### 備考
- 特になし
