### PR TITLE
ref:`drawCardsForPlayer`メソッドの実装とテストコードを追加し、`dealingCard`メソッドの責任を分離

### DIFF
--- a/src/lib/black_jack/Dealer.php
+++ b/src/lib/black_jack/Dealer.php
@@ -8,21 +8,27 @@ require_once(__DIR__.'/Deck.php');
 class Dealer
 {
     public array $dealerCard = [];
-    public function dealingCard(string $playerName): array
+
+    // $playerNamesにはdealerも格納済み
+    public function drawCardsForPlayer(array $playerNames, Deck $deck): array
     {
-        $playerNames = ["$playerName", 'dealer'];
         $playerCards = [];
         // TODO:プレイヤー数増加への対応追加
         // インデント番号が最後の手札はdearlerの手札配列とする
         $indent = 0;
         // カードを山札から引く処理
-        $deck = new Deck;
         $collectionTwoCards = $deck->drawCard();
         // $playersCard配列のキーにプレイヤー名を追加し、プレイヤーと手札を紐づける
         foreach ($collectionTwoCards as $TwoCards) {
             $playerCards[$playerNames[$indent]] = $TwoCards;
             ++$indent;
         }
+        return $playerCards;
+    }
+    
+    public function dealingCard(array $playerNames, Deck $deck): array
+    {
+        $playerCards = $this->drawCardsForPlayer($playerNames, $deck);
         return $playerCards;
     }
 }

--- a/src/lib/black_jack/Deck.php
+++ b/src/lib/black_jack/Deck.php
@@ -12,7 +12,6 @@ class Deck
     {
     }
 
-    // TODO 山札作成（シャフルまで）
     public function makeDeck()
     {
         // 52枚のカードを持つ配列のプロパティを初期設定
@@ -26,9 +25,9 @@ class Deck
     public function drawCard()
     {
         $playerCards = [];
+
         // ディーラー含む２名分のカード４枚をスライス
         // カードを手札用に2枚単位で分割してプレイヤー２名分のカードを準備
-
         $playerCards = array_chunk(array_slice($this->makeDeck(), 0, 4), 2);
         return $playerCards;
     }

--- a/src/tests/black_jack/DealerTest.php
+++ b/src/tests/black_jack/DealerTest.php
@@ -4,17 +4,40 @@ namespace BlackJack\Tests;
 
 use PHPUnit\Framework\TestCase;
 use BlackJack\Dealer;
+use BlackJack\Deck;
 
 require_once(__DIR__ . '/../../lib/black_jack/Dealer.php');
+require_once(__DIR__ . '/../../lib/black_jack/Deck.php');
 
 class DealerTest extends TestCase
 {
+    public function testDrawCardForPlayer()
+    {
+        $mockDeck = $this->createMock(Deck::class);
+        $mockDeck->method('drawCard')->willReturn([
+            ["H1", "D1"],
+            ["H2", "D2"]
+        ]);
+        // print_r($mockDeck->drawCard());
+
+        $dealer = new Dealer;
+        $playerCard = $dealer->drawCardsForPlayer(['takuya', 'dealer'], $mockDeck);
+        $this->assertSame(['H1', 'D1'], $playerCard['takuya']);
+    }
+
     public function testDealingCard()
     {
+        $mockDeck = $this->createMock(Deck::class);
+        $mockDeck->method('drawCard')->willReturn([
+            ["H1", "D1"],
+            ["H2", "D2"]
+        ]);
+
+        // print_r($mockDeck->drawCard());
         $dealer = new Dealer;
         // プレイヤー達のカードの手札が格納された配列を返す
         // $playersCard[名前]=各プレイヤーのカード
-        $playersCard = $dealer->dealingCard('takuya');
+        $playersCard = $dealer->dealingCard(['takuya','dealer'], $mockDeck);
         // 型の確認
         $this->assertSame('array', gettype($playersCard));
         // 人数分の手札の確認
@@ -22,6 +45,9 @@ class DealerTest extends TestCase
         // 各プレイヤーの手札枚数の確認
         foreach($playersCard as $playerCard) {
         $this->assertSame(2, count($playerCard));
+        // プレイヤーとカードが正常に紐づけられているかの確認
+        $this->assertSame(["H1", "D1"], $playersCard['takuya']);
+        $this->assertSame(["H2", "D2"], $playersCard['dealer']);
         }
     }
 }


### PR DESCRIPTION
### プルリクエスト概要
- `dealingCard`メソッドの責任分離の為、カードを取得しプレイヤーに紐づける`drawCardsForPlayer`メソッドを実装。
- テストで以下を確認
    - 山札から取得したカードをプレイヤーに紐づける処理
    - プレイヤー毎の手札配列の返り値

### 変更内容
- `dealingCard`メソッドの中で、`drawCardsForPlayer`メソッドを呼び出す処理に変更

### 確認事項
- [X] コードが意図通りに動作している
- [X] 必要なテストが追加または更新されている

### 備考
- 特になし
