### PR TITLE
feat:初回手札を取得し、プレイヤーと紐づける処理を追加

### DIFF
--- a/src/lib/black_jack/Deck.php
+++ b/src/lib/black_jack/Deck.php
@@ -9,6 +9,8 @@ require_once(__DIR__.'/Card.php');
 class Deck
 {
     public array $cardDeck = [];
+    public array $drawnCards = [];
+
     public function __construct(public Card $card)
     {
     }
@@ -28,5 +30,15 @@ class Deck
         // 山札からカードを取得し、取得したカードは山札から削除
         $drawnCard = array_splice($this->cardDeck, 0, $drawCardNum);
         return $drawnCard;
+    }
+
+    public function getStartHands(array $playerNames) : array
+    {
+        $playerHands = [];
+        foreach($playerNames as $playerName) {
+            $this->drawCard(2);
+            $playerHands[$playerName] = $this->drawnCards;
+        }
+        return $playerHands;
     }
 }

--- a/src/tests/black_jack/DeckTest.php
+++ b/src/tests/black_jack/DeckTest.php
@@ -33,4 +33,14 @@ class DeckTest extends TestCase
         $this->assertSame(false, in_array($drawnCard[1], $deck->cardDeck));
     }
 
+    public function testGetStartHands()
+    {
+        $deck = new Deck(new Card);
+        $deck->makeDeck();
+        $playerHands = $deck->getStartHands(['takuya', 'takashi']);
+
+        // 手札枚数の確認
+        $this->assertSame(2, count($playerHands['takuya']));
+        $this->assertSame(2, count($playerHands['takashi']));
+    }
 }


### PR DESCRIPTION
### プルリクエスト概要
- 手札2枚を山札から取得し、プレイヤー名と紐づけて手札とする処理を追加しました。
- 該当処理のテストコードを実装しました。

### 変更内容
1. 'getStartHands'メソッドを実装し、プレイヤーの手札を取得

### 確認事項
- [X] コードが意図通りに動作している
- [X] 必要なテストが追加または更新されている

### 備考
- 特になし
