### PR TITLE
ref:初回手札を配布する処理を追加

### DIFF
--- a/src/lib/black_jack/Dealer.php
+++ b/src/lib/black_jack/Dealer.php
@@ -9,26 +9,32 @@ class Dealer
 {
     public array $dealerCard = [];
 
-    // $playerNamesにはdealerも格納済み
-    public function drawCardsForPlayer(array $playerNames, Deck $deck): array
+    public function dealStartHands(Deck $deck, array $playerNames) : array
     {
-        $playerCards = [];
-        // TODO:プレイヤー数増加への対応追加
-        // インデント番号が最後の手札はdearlerの手札配列とする
-        $indent = 0;
-        // カードを山札から引く処理
-        $collectionTwoCards = $deck->drawCard();
-        // $playersCard配列のキーにプレイヤー名を追加し、プレイヤーと手札を紐づける
-        foreach ($collectionTwoCards as $TwoCards) {
-            $playerCards[$playerNames[$indent]] = $TwoCards;
-            ++$indent;
-        }
-        return $playerCards;
+        $playerHands = $deck->startHands($playerNames);
+        return $playerHands;
     }
-    
-    public function dealingCard(array $playerNames, Deck $deck): array
-    {
-        $playerCards = $this->drawCardsForPlayer($playerNames, $deck);
-        return $playerCards;
-    }
+
+    // // $playerNamesにはdealerも格納済み
+    // public function drawCardsForPlayer(array $playerNames, Deck $deck): array
+    // {
+    //     $playerCards = [];
+    //     // TODO:プレイヤー数増加への対応追加
+    //     // インデント番号が最後の手札はdearlerの手札配列とする
+    //     $indent = 0;
+    //     // カードを山札から引く処理
+    //     $collectionTwoCards = $deck->drawCard();
+    //     // $playersCard配列のキーにプレイヤー名を追加し、プレイヤーと手札を紐づける
+    //     foreach ($collectionTwoCards as $TwoCards) {
+    //         $playerCards[$playerNames[$indent]] = $TwoCards;
+    //         ++$indent;
+    //     }
+    //     return $playerCards;
+    // }
+
+    // public function dealingCard(array $playerNames, Deck $deck): array
+    // {
+    //     $playerCards = $this->drawCardsForPlayer($playerNames, $deck);
+    //     return $playerCards;
+    // }
 }

--- a/src/tests/black_jack/DealerTest.php
+++ b/src/tests/black_jack/DealerTest.php
@@ -5,49 +5,69 @@ namespace BlackJack\Tests;
 use PHPUnit\Framework\TestCase;
 use BlackJack\Dealer;
 use BlackJack\Deck;
+use BlackJack\Card;
 
 require_once(__DIR__ . '/../../lib/black_jack/Dealer.php');
 require_once(__DIR__ . '/../../lib/black_jack/Deck.php');
+require_once(__DIR__ . '/../../lib/black_jack/Card.php');
 
 class DealerTest extends TestCase
 {
-    public function testDrawCardForPlayer()
-    {
-        $mockDeck = $this->createMock(Deck::class);
-        $mockDeck->method('drawCard')->willReturn([
-            ["H1", "D1"],
-            ["H2", "D2"]
-        ]);
-        // print_r($mockDeck->drawCard());
-
+    public function testDealStartCard() {
+        $deck = new Deck(new Card);
         $dealer = new Dealer;
-        $playerCard = $dealer->drawCardsForPlayer(['takuya', 'dealer'], $mockDeck);
-        $this->assertSame(['H1', 'D1'], $playerCard['takuya']);
+        $playerNames = ['takuya'];
+        $playerHands = $dealer->dealStartHands($deck, $playerNames);
+
+        // プレイヤーの人数分の手札の有無
+        $this->assertSame(count($playerNames), count($playerHands));
+        // プレイヤーが2人の場合
+        $playerNames = ['takuya', 'akemi'];
+        $playerHands = $dealer->dealStartHands($deck, $playerNames);
+        $this->assertSame(count($playerNames), count($playerHands));
+        // プレイヤーが3人の場合
+        $playerNames = ['takuya', 'akemi', 'kawasaki'];
+        $playerHands = $dealer->dealStartHands($deck, $playerNames);
+        $this->assertSame(count($playerNames), count($playerHands));
     }
 
-    public function testDealingCard()
-    {
-        $mockDeck = $this->createMock(Deck::class);
-        $mockDeck->method('drawCard')->willReturn([
-            ["H1", "D1"],
-            ["H2", "D2"]
-        ]);
+    // public function testDrawCardForPlayer()
+    // {
+    //     $mockDeck = $this->createMock(Deck::class);
+    //     $mockDeck->method('drawCard')->willReturn([
+    //         ["H1", "D1"],
+    //         ["H2", "D2"]
+    //     ]);
+    //     // print_r($mockDeck->drawCard());
 
-        // print_r($mockDeck->drawCard());
-        $dealer = new Dealer;
-        // プレイヤー達のカードの手札が格納された配列を返す
-        // $playersCard[名前]=各プレイヤーのカード
-        $playersCard = $dealer->dealingCard(['takuya','dealer'], $mockDeck);
-        // 型の確認
-        $this->assertSame('array', gettype($playersCard));
-        // 人数分の手札の確認
-        $this->assertSame(2, count($playersCard));
-        // 各プレイヤーの手札枚数の確認
-        foreach($playersCard as $playerCard) {
-        $this->assertSame(2, count($playerCard));
-        // プレイヤーとカードが正常に紐づけられているかの確認
-        $this->assertSame(["H1", "D1"], $playersCard['takuya']);
-        $this->assertSame(["H2", "D2"], $playersCard['dealer']);
-        }
-    }
+    //     $dealer = new Dealer;
+    //     $playerCard = $dealer->drawCardsForPlayer(['takuya', 'dealer'], $mockDeck);
+    //     $this->assertSame(['H1', 'D1'], $playerCard['takuya']);
+    // }
+
+    // public function testDealingCard()
+    // {
+    //     $mockDeck = $this->createMock(Deck::class);
+    //     $mockDeck->method('drawCard')->willReturn([
+    //         ["H1", "D1"],
+    //         ["H2", "D2"]
+    //     ]);
+
+    //     // print_r($mockDeck->drawCard());
+    //     $dealer = new Dealer;
+    //     // プレイヤー達のカードの手札が格納された配列を返す
+    //     // $playersCard[名前]=各プレイヤーのカード
+    //     $playersCard = $dealer->dealingCard(['takuya','dealer'], $mockDeck);
+    //     // 型の確認
+    //     $this->assertSame('array', gettype($playersCard));
+    //     // 人数分の手札の確認
+    //     $this->assertSame(2, count($playersCard));
+    //     // 各プレイヤーの手札枚数の確認
+    //     foreach($playersCard as $playerCard) {
+    //     $this->assertSame(2, count($playerCard));
+    //     // プレイヤーとカードが正常に紐づけられているかの確認
+    //     $this->assertSame(["H1", "D1"], $playersCard['takuya']);
+    //     $this->assertSame(["H2", "D2"], $playersCard['dealer']);
+    //     }
+    // }
 }


### PR DESCRIPTION
### プルリクエスト概要
- 全体構成の変更により、初回手札配布関数を再実装しました。以前の関数はコメントアウトし、一旦退避させています（不要であれば削除します）。

### 変更内容
1. `dealStartHands`関数を作成し、プレイヤー名をキーとする初回手札配列を作成。

### 確認事項
- [X] コードが意図通りに動作している
- [X] 必要なテストが追加または更新されている

### 備考
- 特になし
