### PR TITLE
ref:dealerが初回カードを取得する処理を追加

### DIFF
--- a/src/lib/black_jack/Dealer.php
+++ b/src/lib/black_jack/Dealer.php
@@ -7,12 +7,20 @@ require_once(__DIR__.'/Deck.php');
 
 class Dealer
 {
+    const FIRST_CARD_NUMBER = 2;
     public array $dealerCard = [];
 
     public function dealStartHands(Deck $deck, array $playerNames) : array
     {
         $playerHands = $deck->startHands($playerNames);
         return $playerHands;
+    }
+
+    public function makeDealerHand(Deck $deck) :array
+    {
+        $dealerHand = $deck->drawCard(self::FIRST_CARD_NUMBER);
+
+        return $dealerHand;
     }
 
     // // $playerNamesにはdealerも格納済み

--- a/src/lib/black_jack/Deck.php
+++ b/src/lib/black_jack/Deck.php
@@ -8,6 +8,7 @@ require_once(__DIR__.'/Card.php');
 
 class Deck
 {
+    // ゲームで使用する山札
     public array $cardDeck = [];
     public array $drawnCard = [];
 

--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -9,7 +9,7 @@ require_once(__DIR__.'/Dealer.php');
 class Game
 {
     const PLAYER_NAME_INDENT = 0;
-    public $deck = [];
+    public Deck $deck;
 
     public function __construct(public array $playerNames)
     {
@@ -29,14 +29,13 @@ class Game
         echo "あなたの引いたカードは{$playerHands[$this->playerNames[Game::PLAYER_NAME_INDENT]][0]}です。";
         echo "あなたの引いたカードは{$playerHands[$this->playerNames[Game::PLAYER_NAME_INDENT]][1]}です。";
 
-        return $playerHands;
+        $dealerHand = $dealer->makeDealerHand($deck);
+        echo "ディーラーの引いたカードは{$dealerHand[0]}です。";
+        echo 'ディーラーの引いた2枚目のカードはわかりません。';
+
+        return $dealerHand;
     }
-
-        // $dealerHand = $dealer->makeDealerHand();
-        // // TODO:$playerCardsにdealerのカード含めるか確認したほうがいい
-        // echo "ディーラーの引いたカードは$playerCards[$dealer][0]です。";
-        // echo 'ディーラーの引いた2枚目のカードはわかりません。';
-
+}
         // // playerが必要に応じて追加カードを引く
         // // playerNameをplayerHandsのキーに代入して、そのプレイヤーのカードを呼出し。手札を確認し必用であれば追加でカードを引く。最終的に勝負するカードを返り値とする
         // // 初期値で名前と手札を設定
@@ -76,4 +75,3 @@ class Game
 // ディーラーの得点は22です。
 // あなたの勝ちです！
 // ブラックジャックを終了します。
-}

--- a/src/tests/black_jack/DealerTest.php
+++ b/src/tests/black_jack/DealerTest.php
@@ -31,6 +31,14 @@ class DealerTest extends TestCase
         $this->assertSame(count($playerNames), count($playerHands));
     }
 
+    public function tesMakeDealerHand() {
+        $deck = new Deck(new Card);
+        $dealer = new Dealer;
+
+        // カードの枚数
+        $this->assertSame(2, $dealer->makeDealerHand($deck));
+    }
+
     // public function testDrawCardForPlayer()
     // {
     //     $mockDeck = $this->createMock(Deck::class);

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -17,6 +17,6 @@ class GameTest extends TestCase
         $this->assertSame('array', gettype($playerHand));
 
         // 各プレイヤーの手札枚数の確認
-        $this->assertSame(2, count($playerHand['takuya']));
+        $this->assertSame(2, count($playerHand));
     }
 }


### PR DESCRIPTION
### プルリクエスト概要
- `dealer`が2枚の初回カードを取得する処理を追加

### 変更内容
- `deck`クラスに追加カード取得処理の実行を指示
- 返り値として配列型の手札を返す
- `game`クラスの返り値はテスト用に仮実装

### テスト確認事項
- 取得したカードの枚数を確認

### 備考
- 特になし
