### PR TITLE
feat:手札のポイント計算処理と、テストコードを追加

### DIFF
--- a/src/lib/black_jack/PointCalculator.php
+++ b/src/lib/black_jack/PointCalculator.php
@@ -5,6 +5,22 @@ namespace BlackJack;
 class PointCalculator {
 
     public function calculatePoint(array $hand) : int {
-        return 1;
+
+      // 手札カードをrank化。スートを除去により。
+      $ranks = [];
+      foreach($hand as $card) {
+        $rank = substr($card, 1);
+
+        // rankがJ,Q,K,Aの場合に'10'に変換
+        $aceAndFaceCards = ['J', 'Q', 'K', 'A'];
+        if (in_array($rank, $aceAndFaceCards)) {
+            $rank = 10;
+        }
+        $ranks[] = (int)$rank;
+      }
+      // 手札スコアを計算。rankを合算して。
+      $score = array_sum($ranks);
+      // 出力
+        return $score;
     }
 }

--- a/src/lib/black_jack/PointCalculator.php
+++ b/src/lib/black_jack/PointCalculator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BlackJack;
+
+class PointCalculator {
+
+    public function calculatePoint(array $hand) : int {
+        return 1;
+    }
+}

--- a/src/tests/black_jack/PointCalculatorTest.php
+++ b/src/tests/black_jack/PointCalculatorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BlackJack\Tests;
+
+use PHPUnit\Framework\TestCase;
+use BlackJack\PointCalculator;
+
+require_once(__DIR__ . '/../../lib/black_jack/PointCalculator.php');
+
+class PointCalculatorTest extends TestCase {
+
+  public function testPointCalculator() {
+      $pointCalculator = new PointCalculator;
+      $point = $pointCalculator->calculatePoint(['H3', 'H1']);
+      $this->assertSame(4, $point);
+      $point = $pointCalculator->calculatePoint(['HQ', 'DK', 'K1']);
+      $this->assertSame(21, $point);
+  }
+}

--- a/src/tests/black_jack/PointCalculatorTest.php
+++ b/src/tests/black_jack/PointCalculatorTest.php
@@ -15,5 +15,11 @@ class PointCalculatorTest extends TestCase {
       $this->assertSame(4, $point);
       $point = $pointCalculator->calculatePoint(['HQ', 'DK', 'K1']);
       $this->assertSame(21, $point);
+      $point = $pointCalculator->calculatePoint(['HQ', 'DK', 'KA']);
+      $this->assertSame(30, $point);
+      $point = $pointCalculator->calculatePoint(['SJ', 'KK', 'SA']);
+      $this->assertSame(30, $point);
+      $point = $pointCalculator->calculatePoint(['S4', 'KA', 'S1']);
+      $this->assertSame(15, $point);
   }
 }


### PR DESCRIPTION
### プルリクエスト概要
- feat:手札のポイント計算処理と、テストコードを追加しました。

### 変更内容
- 手札のrank部分を分離し、合算する処理を追加
- 合算したスコアを返り値として設定

### テスト確認事項
- rankが適切に変換され、スコアとして正しいく値が返ること

### 備考
- 
