### PR TITLE
feat:`Game`クラスのカード追加処理を修正

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -15,7 +15,7 @@ class Game
     const PLAYER_NAME_INDENT = 0;
     public function __construct(
         // 必須引数（Deck $deck）はデフォルト値を持つ引数の前に置く必要があります。これに違反すると、エラーになります。
-        Deck $deck,
+        public Deck $deck,
         public array $playerNames,
         // ?でnullable型に指定し、nullを許容
         public ?Dealer $dealer = null,
@@ -49,24 +49,26 @@ class Game
 
              // 追加カードによりバーストしていた場合はゲーム終了
             if ($playerScore > 21) {
-                echo 'あなたの負けです。';
-                break;
+                return 'あなたの負けです。';
             }
 
             echo "あなたの現在の得点は{$playerScore}です。カードを引きますか？（Y/N）";
             $input = trim(fgets(STDIN));
+
+            // 追加のカードを引く場合
             if ($input == 'Y') {
-                // playerHandの最後の値を取得
-                $playerHand = $player->addCard($this->dealer, $this->deck, $playerHands[$this->playerNames[Game::PLAYER_NAME_INDENT]]);
-                // 追加したカードをユーザーに表示
-                $lastAdditionalCard = end($playerHand);
+                // 追加のカードを取得し、プレイヤー手札に代入
+                $playerHands[$this->playerNames[Game::PLAYER_NAME_INDENT]] = $player->addCard($this->dealer, $this->deck, $playerHands[$this->playerNames[Game::PLAYER_NAME_INDENT]]);
+                // 手札の最後の値を取得し、値＝追加カードをユーザーへ表示
+                $lastAdditionalCard = end($playerHands[$this->playerNames[Game::PLAYER_NAME_INDENT]]);
                 echo "あなたの引いたカードは{$lastAdditionalCard}です。";
-                $playerScore = $this->pointCalculator->calculatePoint($playerHands[$this->playerNames[Game::PLAYER_NAME_INDENT]]);
+                //再ループ
                 continue;
             }
-            break;
-            }
-        return 'テスト完了';
+
+            // 追加のカードを引かない場合の仮実装
+            return 'テスト完了';
+        }
     }
 }
         // // playerが必要に応じて追加カードを引く

--- a/src/lib/black_jack/Player.php
+++ b/src/lib/black_jack/Player.php
@@ -18,7 +18,7 @@ class Player
 
     public function addCard(Dealer $dealer, Deck $deck, array $playerHand): array
     {
-        $playerHand[] = $dealer->dealAddCard($deck);
+        $playerHand = array_merge($playerHand, $dealer->dealAddCard($deck));
         return $playerHand;
     }
 }

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -4,19 +4,36 @@ namespace BlackJack\Tests;
 
 use PHPUnit\Framework\TestCase;
 use BlackJack\Game;
-
+use BlackJack\Deck;
+use BlackJack\Card;
+require_once(__DIR__ . '/../../lib/black_jack/Card.php');
+require_once(__DIR__ . '/../../lib/black_jack/Deck.php');
 require_once(__DIR__ . '/../../lib/black_jack/Game.php');
+
 
 class GameTest extends TestCase
 {
     public function testStart()
     {
-        $game = new Game(['takuya']);
+        $card = new Card;
+        $deck = new Deck($card);
+        $game = new Game($deck, ['takuya']);
+
+        // スコアが21を超えた場合に、バースト判定の確認
+        $deck->cardDeck =['P5', 'P5', 'D10', 'D10', 'P15'];
         $playerHand = $game->start();
+        $this->assertSame('あなたの負けです。', $playerHand);
+
+        // 追加のカードを引かない場合の仮実装
+        $deck->cardDeck =['P5', 'P5', 'D10', 'D10', 'P11'];
+        $playerHand = $game->start();
+        $this->assertSame('テスト完了', $playerHand);
+
         // 型の確認
         // $this->assertSame('array', gettype($playerHand));
 
-        // 各プレイヤーの手札枚数の確認
-        $this->assertSame('テスト完了', $playerHand);
+        // $card->cards =['H8', 'D3', 'S10'];
+        // // 各プレイヤーの手札枚数の確認
+        // $this->assertSame('テスト完了', $playerHand);
     }
 }


### PR DESCRIPTION
### プルリクエスト概要
- `Game`クラスのカード追加処理を修正しました。

### 変更内容
- 各処理をコメントで概要記入
- 手札取得時、代入処理の不具合を修正
- `break`を`return`に変更、処理と出力を分離する事で拡張性向上
- 不要なスコア計算処理を削除
- 結合テストを実施、動作を確認

### テスト確認事項
- カード追加でバーストした場合の出力を確認
- カートを追加しない場合の出力を確認

### 備考
- カードを追加しない場合の処理は実装途中。
