### PR TITLE
refactor: 'Game'クラスから'drawStartHands'メソッドを切り出し、'GameProcess'クラスに移行

### DIFF
--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -13,12 +13,32 @@ require_once(__DIR__.'/Deck.php');
 
 class GameProcess {
 
+    const PLAYER_NAME_INDENT = 0;
+
     public function __construct(
         public Dealer $dealer,
         public Deck $deck,
         public PointCalculator $pointCalculator
     )
     {}
+
+    public function drawStartHands(array $playerNames) //: void
+    {
+        // $player = new Player($playerNames[self::PLAYER_NAME_INDENT]);
+
+        // 山札からカード取得。プレイヤー名をキーとする連想配列を、プレイヤーの人数分作成。
+        $playerHands = $this->dealer->dealStartHands($this->deck, $playerNames);
+        $dealerHand = $this->dealer->makeDealerHand($this->deck);
+
+        echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][0]}です。";
+        echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][1]}です。";
+        echo "ディーラーの引いたカードは{$dealerHand[0]}です。";
+        echo 'ディーラーの引いた2枚目のカードはわかりません。';
+
+        // テスト用返り値を設定
+        $hands = ['playerHands' => $playerHands, 'dealerHand' => $dealerHand];
+        return $hands;
+    }
 
     private const DRAW_STOP_SCORE = 17;
 

--- a/src/tests/black_jack/GameProcessTest.php
+++ b/src/tests/black_jack/GameProcessTest.php
@@ -17,11 +17,25 @@ require_once(__DIR__ . '/../../lib/black_jack/PointCalculator.php');
 
 class GameProcessTest extends TestCase
 {
+    public function testDrawStartHands() {
+        $deck = new Deck(new Card);
+        $pointCalculator = new PointCalculator;
+        $mock = $this->createMock(Dealer::class);
+        $mock->method('dealStartHands')->willReturn(['takuya' => ['K1', 'K2']]);
+        $mock->method('makeDealerHand')->willReturn(['D1', 'D2']);
+        $gameProcess = new GameProcess($mock, $deck, $pointCalculator);
+        $hands = $gameProcess->drawStartHands(['takuya']);
+        $this->assertSame(['takuya' => ['K1', 'K2']], $hands['playerHands']);
+    }
+
     public function testDealerTurn() {
+        $deck = new Deck(new Card);
+        $pointCalculator = new PointCalculator;
+
         $mock = $this->createMock(Dealer::class);
         $mock->method('dealAddCard')->willReturn(['H6']);
 
-        $gameProcess = new GameProcess($mock, new Deck(new Card), new PointCalculator);
+        $gameProcess = new GameProcess($mock, $deck, $pointCalculator);
         $dealerScore = $gameProcess->dealerTurn(['D1', 'DA'], 11);
         $this->assertSame(23, $dealerScore);
     }


### PR DESCRIPTION
- 'GameProcess'クラスに'drawStartHands'メソッドを新規作成
- 機能を移行し、責務を分離
- 'Game'クラスからメソッドを削除し、関連部分を修正
