### PR TITLE
ref:'Game'クラスから'GameProcess'クラスへ、dealerの追加カード取得処理を移行

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -42,14 +42,7 @@ class Game
         $playerScore = $this->gameProcess->addPlayerCard('N', $hands, $this->yourName, $player);
 
         // ディーラーのカード追加処理
-        // ディーラーの2枚目のカードを開示
-        echo "ディーラーの引いた2枚目のカードは{$hands['dealerHand'][1]}でした。";
-        $dealerScore = $this->pointCalculator->calculatePoint($hands['dealerHand']);
-        echo "ディーラーの現在の得点は{$dealerScore}です。";
-
-        $dealerScore = $this->gameProcess->dealerTurn($hands['dealerHand'], $dealerScore);
-
-        echo "ディーラーの現在の得点は{$dealerScore}です。";
+        $dealerScore = $this->gameProcess->addDealerCard($hands);
 
         return 'テスト用出力';
         // echo "あなたの得点は{$playerScore}です。";

--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace BlackJack;
-
 use BlackJack\Dealer;
 use BlackJack\Deck;
 use BlackJack\Player;
@@ -43,8 +42,9 @@ class GameProcess {
     }
 
     private const DRAW_STOP_SCORE = 17;
-
-    public function dealerTurn(array $dealerHand, int $dealerScore): int {
+    // TODO:処理の順序を、カード処理と出力に分離したほうがいいのでは？
+    public function dealerTurn(array $dealerHand, int $dealerScore): int
+    {
         // dealerのカードが規定値以下の場合、カードを取得
         while (self::DRAW_STOP_SCORE >= $dealerScore) {
             // カードを取得、山札から。
@@ -55,6 +55,19 @@ class GameProcess {
             // 手札のスコアを計算して出力
             $dealerScore = $this->pointCalculator->calculatePoint($dealerHand);
         }
+        return $dealerScore;
+    }
+
+    public function addDealerCard(array $hands): int
+    {
+        // ディーラーの2枚目のカードを開示
+        $dealerScore = $this->pointCalculator->calculatePoint($hands['dealerHand']);
+        echo "ディーラーの引いた2枚目のカードは{$hands['dealerHand'][1]}でした。";
+        echo "ディーラーの現在の得点は{$dealerScore}です。";
+
+        $dealerScore = $this->dealerTurn($hands['dealerHand'], $dealerScore);
+        echo "ディーラーの現在の得点は{$dealerScore}です。";
+
         return $dealerScore;
     }
 

--- a/src/tests/black_jack/GameProcessTest.php
+++ b/src/tests/black_jack/GameProcessTest.php
@@ -42,6 +42,23 @@ class GameProcessTest extends TestCase
         $this->assertSame(23, $dealerScore);
     }
 
+    public function testAddDealerCard()
+    {
+        $deck = new Deck(new Card);
+        $pointCalculator = new PointCalculator;
+
+        $dealerMock = $this->getMockBuilder(Dealer::class)
+        ->onlyMethods(['dealAddCard'])
+        ->getMock();
+        $dealerMock->method('dealAddCard')->willReturn(['H10']);
+
+        $gameProcess = new GameProcess($dealerMock, $deck, $pointCalculator);
+        $dealerScore = $gameProcess->addDealerCard(['dealerHand' => ['D6', 'D5']]);
+
+        // 返り値を確認
+        $this->assertSame(21, $dealerScore);
+    }
+
     public function testAddPlayerCard()
     {
         $deck = new Deck(new Card);


### PR DESCRIPTION
### プルリクエスト概要
- 責務の分離を目的とし、dealerの追加カード取得処理を、'Game'クラスから'GameProcess'クラスに移行しました。
- 追加した'addDealerCard'メソッドに対する単体テストを実装し、正常な処理を確認しました。

### 変更内容
- メソッドの追加
  - GameProcess.addDealerCard():
    - dealerにカードを追加するロジックを実装
- テストの更新
  - GameProcessTest
  - 'addDealerCard()'のテストを追加

### テスト確認事項
-  新規追加したテストケースが適切に動作し、期待通りの結果を返すことを確認。
