### PR TITLE
feat: 勝者を判定し、出力する処理を実装

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -27,7 +27,7 @@ class Game
     }
 
     const PLAYER_NAME_INDENT = 0;
-    public function start()
+    public function start(): string
     {
         // 操作プレイヤーの名前を取得
         $this->yourName = $this->playerNames[self::PLAYER_NAME_INDENT];
@@ -44,13 +44,9 @@ class Game
         // ディーラーのカード追加処理
         $dealerScore = $this->gameProcess->addDealerCard($hands);
 
-        return 'テスト用出力';
-        // echo "あなたの得点は{$playerScore}です。";
-        // echo "ディーラーの得点は{$dealerScore}です。";
-        //         // あなたの勝ちです！
-        // $winnerMessage = $dealer->judgeWinner($playerHand);
-        // return $winnerMessage;
-        // ブラックジャックを終了します。
+        // 勝敗の判定
+        $this->gameProcess->judgeWinner($playerScore, $dealerScore, $player->playerName);
+        return 'ブラックジャックを終了します。';
     }
 }
 

--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace BlackJack;
+
 use BlackJack\Dealer;
 use BlackJack\Deck;
 use BlackJack\Player;
@@ -101,5 +102,19 @@ class GameProcess {
             }
             return $playerScore;
         }
+    }
+
+    public function judgeWinner(int $playerScore, int $dealerScore, string $playerName): string
+    {
+        $winner = 'ディーラー';
+        if ($playerScore > $dealerScore) {
+            $winner = $playerName;
+        }
+
+        // 勝者名を出力
+        echo "あなたの得点は{$playerScore}です。";
+        echo "ディーラーの得点は{$dealerScore}です。";
+        echo "{$winner}の勝ちです！";
+        return $winner;
     }
 }

--- a/src/tests/black_jack/GameProcessTest.php
+++ b/src/tests/black_jack/GameProcessTest.php
@@ -89,4 +89,20 @@ class GameProcessTest extends TestCase
         // $this->assertSame('テスト用出力', $playerHand);
     }
 
+    public function testJudgeWinner()
+    {
+        $deck = new Deck(new Card);
+        $pointCalculator = new PointCalculator;
+
+        $mock = $this->createMock(Dealer::class);
+
+        // 返り値の確認
+        $gameProcess = new GameProcess($mock, $deck, $pointCalculator);
+        $winner = $gameProcess->judgeWinner(21, 20, 'takuya');
+        $this->assertSame('takuya', $winner);
+
+        $winner = $gameProcess->judgeWinner(20, 21, 'takuya');
+        $this->assertSame('ディーラー', $winner);
+    }
+
 }

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -27,6 +27,6 @@ class GameTest extends TestCase
         $pointCalculator = new PointCalculator;
         $gameProcess = new GameProcess($dealer, $deck, $pointCalculator);
         $game = new Game($deck, $gameProcess, $dealer, $pointCalculator, ['takuya'], 'takuya');
-        $this->assertSame('テスト用出力', $game->start());
+        $this->assertSame('ブラックジャックを終了します。', $game->start());
     }
 }


### PR DESCRIPTION
### プルリクエスト概要
- 勝者を判定し、出力をする処理を追加しました。

### 変更内容
- 勝者名を判定するロジックを追加

### テスト確認事項
- テストにて適切に勝者名が出力される事を確認 

### 備考
- 
