### PR TITLE
feat:プレイヤーが追加カード取得後、バーストした場合の処理を追加

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -38,13 +38,17 @@ class Game
         // 初回カード取得
         $hands = $this->gameProcess->drawStartHands($this->playerNames);
         // プレイヤーの追加カード取得
-        $playerScore = $this->gameProcess->addPlayerCard($hands, $this->yourName, $player);
+        $playerResult = $this->gameProcess->addPlayerCard($hands, $this->yourName, $player);
+        if ($playerResult === 'あなたの負けです。') {
+            echo "$playerResult";
+            return 'ブラックジャックを終了します。';
+        }
 
         // ディーラーのカード追加処理
         $dealerScore = $this->gameProcess->addDealerCard($hands);
 
         // 勝敗の判定
-        $this->gameProcess->judgeWinner($playerScore, $dealerScore, $player->playerName);
+        $this->gameProcess->judgeWinner($playerResult, $dealerScore, $player->playerName);
         return 'ブラックジャックを終了します。';
     }
 }

--- a/src/tests/black_jack/GameProcessTest.php
+++ b/src/tests/black_jack/GameProcessTest.php
@@ -71,14 +71,12 @@ class GameProcessTest extends TestCase
         // 返り値の確認
         $gameProcess = new GameProcess($mock, $deck, $pointCalculator);
         $playerScore = $gameProcess->addPlayerCard(
-            // ['Y', 'N'],
             ['playerHands' => ['takuya' => ['D6', 'D7']]],
             'takuya', $player);
         $this->assertSame(16, $playerScore);
 
         // スコアが21を超えた場合に、バースト判定の確認
         $message = $gameProcess->addPlayerCard(
-            // ['Y'],
             ['playerHands' => ['takuya' => ['D6', 'D7']]],
             'takuya', $player);
         $this->assertSame('あなたの負けです。', $message);


### PR DESCRIPTION
### プルリクエスト概要
- プレイヤーが追加カード取得後、バーストした場合にゲームを終了する処理を追加しました。

### 変更内容
1. 追加カード取得結果を判定
  - プレイヤーが追加カード取得後、返り値を確認。
  - 値が’あなたの負けです。'の場合、ゲームを終了。

2. 勝敗判定の引数修正
  - 'judgeWinner'メソッドの引数として'$playerScore'ではなく、'$playerResult'を渡すように変更。
  - プレイヤーのスコアに加え、結果を直接活用できるように修正。

### テスト確認事項
- 修正後、テストでエラー発生。
  - 原因：規定値削除によりカードの数値がランダム化し、アサートで期待値と一致しない。
  - 対応：ストリームラッパーによる対応が必要。
  
### 備考
- 
