### PR TITLE
test:テスト時のユーザー入力を、モックストリームに切り替え、規定値の代入処理を実装

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -15,7 +15,7 @@ require_once(__DIR__.'/GameProcess.php');
 class Game
 {
     public function __construct(
-        // 必須引数（Deck $deck）はデフォルト値を持つ引数の前に置く必要があります。これに違反すると、エラーになります。
+        // 必須引数（Deck $deckなど）はデフォルト値を持つ引数の前に置く必要があります。これに違反すると、エラーになります。
         public Deck $deck,
         public GameProcess $gameProcess,
         public Dealer $dealer,
@@ -53,10 +53,11 @@ class Game
     }
 }
 
-$card = new Card;
-$deckInstance = new Deck($card);
-$dealer = new Dealer;
-$pointCalculator = new PointCalculator;
-$gameProcess = new GameProcess($dealer, $deckInstance, $pointCalculator);
-$game = new Game($deckInstance, $gameProcess, $dealer, $pointCalculator, ['takuya']);
-$game->start();
+// Gameクラスの動作確認
+// $card = new Card;
+// $deckInstance = new Deck($card);
+// $dealer = new Dealer;
+// $pointCalculator = new PointCalculator;
+// $gameProcess = new GameProcess($dealer, $deckInstance, $pointCalculator);
+// $game = new Game($deckInstance, $gameProcess, $dealer, $pointCalculator, ['takuya']);
+// $game->start();

--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -21,10 +21,10 @@ class GameProcess {
         public Dealer $dealer,
         public Deck $deck,
         public PointCalculator $pointCalculator,
-        private $inputHandle = null // テスト時に、ストリームラッパーを代入
+        private $inputHandle = null // テスト時に、ストリームハンドルを代入
     )
     {
-        $this->inputHandle = $inputHandle ?? STDIN; // nullの場合は標準有力から入力を受ける
+        $this->inputHandle = $inputHandle ?? STDIN; // nullの場合は標準入力から入力を受ける
     }
 
     public function drawStartHands(array $playerNames) //: void

--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -20,9 +20,12 @@ class GameProcess {
     public function __construct(
         public Dealer $dealer,
         public Deck $deck,
-        public PointCalculator $pointCalculator
+        public PointCalculator $pointCalculator,
+        private $inputHandle = null // テスト時に、ストリームラッパーを代入
     )
-    {}
+    {
+        $this->inputHandle = $inputHandle ?? STDIN; // nullの場合は標準有力から入力を受ける
+    }
 
     public function drawStartHands(array $playerNames) //: void
     {
@@ -83,7 +86,7 @@ class GameProcess {
             }
 
             echo "あなたの現在の得点は{$playerScore}です。カードを引きますか？（Y/N）";
-            $input = trim(fgets(STDIN));
+            $input = trim(fgets($this->inputHandle));
 
             // 追加のカードを引く場合
             if ($input == 'Y') {

--- a/src/tests/black_jack/GameProcessTest.php
+++ b/src/tests/black_jack/GameProcessTest.php
@@ -19,17 +19,18 @@ require_once(__DIR__ . '/../../lib/black_jack/PointCalculator.php');
 
 class GameProcessTest extends TestCase
 {
+    private $handle = '';
     public function setUp(): void
     {
         // TestCaseのメソッド呼出し
         parent::setUp();
         // デフォルトモック値を設定
-        $GLOBALS['STDIN'] = fopen('php://temp', 'r+');
+        $this->handle = fopen('php://temp', 'r+');
     }
 
     public function tearDown(): void
     {
-        fclose($GLOBALS['STDIN']);
+        fclose($this->handle);
         // TestCaseのメソッド呼出して初期化
         parent::tearDown();
     }
@@ -89,18 +90,18 @@ class GameProcessTest extends TestCase
         $mock->method('dealAddCard')->willReturnOnConsecutiveCalls(['D3'], ['K10']);
 
         // 返り値の確認
-        fwrite($GLOBALS['STDIN'],  "Y\nN\n"); // ユーザー入力の代替値を設定
-        rewind($GLOBALS['STDIN']); //ストリームポインタをリセット
+        fwrite($this->handle,  "Y\nN\n"); // ユーザー入力の代替値を設定
+        rewind($this->handle); //ストリームポインタをリセット
 
-        $gameProcess = new GameProcess($mock, $deck, $pointCalculator, $GLOBALS['STDIN']);
+        $gameProcess = new GameProcess($mock, $deck, $pointCalculator, $this->handle);
         $playerScore = $gameProcess->addPlayerCard(
             ['playerHands' => ['takuya' => ['D6', 'D7']]],
             'takuya', $player);
         $this->assertSame(16, $playerScore);
 
         // スコアが21を超えた場合に、バースト判定の確認
-        fwrite($GLOBALS['STDIN'],  "Y\nY\n");
-        rewind($GLOBALS['STDIN']); 
+        fwrite($this->handle,  "Y\nY\n");
+        rewind($this->handle);
 
         $message = $gameProcess->addPlayerCard(
             ['playerHands' => ['takuya' => ['D6', 'D7']]],

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -19,13 +19,37 @@ require_once(__DIR__ . '/../../lib/black_jack/PointCalculator.php');
 
 class GameTest extends TestCase
 {
+  public function setUp(): void
+  {
+      // TestCaseのメソッド呼出し
+      parent::setUp();
+      // デフォルトモック値を設定
+      $GLOBALS['STDIN'] = fopen('php://temp', 'r+');
+
+      // デフォルトのストリームラッパーをモックに置き換える
+      // stream_wrapper_unregister('php');
+      // stream_wrapper_register('php', MockStreamWrapper::class);
+  }
+
+  public function tearDown(): void
+  {
+      // stream_wrapper_restore('php');
+      fclose($GLOBALS['STDIN']);
+      // TestCaseのメソッド呼出して初期化
+      parent::tearDown();
+  }
+
     public function testStart()
     {
+        // 返り値の確認
+        fwrite($GLOBALS['STDIN'],  "Y"); // ユーザー入力の代替値を設定
+        rewind($GLOBALS['STDIN']); //ストリームポインタをリセット
+
         $card = new Card;
         $deck = new Deck($card);
         $dealer = new Dealer($deck);
         $pointCalculator = new PointCalculator;
-        $gameProcess = new GameProcess($dealer, $deck, $pointCalculator);
+        $gameProcess = new GameProcess($dealer, $deck, $pointCalculator, $GLOBALS['STDIN']);
         $game = new Game($deck, $gameProcess, $dealer, $pointCalculator, ['takuya']);
         $this->assertSame('ブラックジャックを終了します。', $game->start());
     }

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -19,22 +19,19 @@ require_once(__DIR__ . '/../../lib/black_jack/PointCalculator.php');
 
 class GameTest extends TestCase
 {
+  private $inputHandle = '';
   public function setUp(): void
   {
       // TestCaseのメソッド呼出し
       parent::setUp();
       // デフォルトモック値を設定
-      $GLOBALS['STDIN'] = fopen('php://temp', 'r+');
-
-      // デフォルトのストリームラッパーをモックに置き換える
-      // stream_wrapper_unregister('php');
-      // stream_wrapper_register('php', MockStreamWrapper::class);
+      $this->inputHandle = fopen('php://temp', 'r+');
   }
 
   public function tearDown(): void
   {
       // stream_wrapper_restore('php');
-      fclose($GLOBALS['STDIN']);
+      fclose($this->inputHandle);
       // TestCaseのメソッド呼出して初期化
       parent::tearDown();
   }
@@ -42,14 +39,14 @@ class GameTest extends TestCase
     public function testStart()
     {
         // 返り値の確認
-        fwrite($GLOBALS['STDIN'],  "Y"); // ユーザー入力の代替値を設定
-        rewind($GLOBALS['STDIN']); //ストリームポインタをリセット
+        fwrite($this->inputHandle, "Y"); // ユーザー入力の代替値を設定
+        rewind($this->inputHandle); //ストリームポインタをリセット
 
         $card = new Card;
         $deck = new Deck($card);
         $dealer = new Dealer($deck);
         $pointCalculator = new PointCalculator;
-        $gameProcess = new GameProcess($dealer, $deck, $pointCalculator, $GLOBALS['STDIN']);
+        $gameProcess = new GameProcess($dealer, $deck, $pointCalculator, $this->inputHandle);
         $game = new Game($deck, $gameProcess, $dealer, $pointCalculator, ['takuya']);
         $this->assertSame('ブラックジャックを終了します。', $game->start());
     }


### PR DESCRIPTION
### プルリクエスト概要
- テスト時、ユーザー入力をストリームラッパーに切り替て規定値を代入処理を実装し、ユーザー入力を自動化しました。
- `GameProcess`クラスに依存性注入を導入し、ユーザー入力の切り替えを明示的に行えるようにしました。

### 変更内容
- `GameProcess`クラス
  - コンストラクタに `inputHandle` を追加し、未指定の場合は`STDIN`を使うように変更
  - `fgets`の呼び出し元を `inputHandle`に統一

- `GameProcessTest`クラス
  - php://temp というラッパーを利用し、fopen を使って一時的なストリームハンドル(ストリームへのインターフェース)を取得。これをモック入力用のストリームとして使用。
  - `GameProcess`にモックストリームを注入し、テスト時のユーザー入力を自動化

- その他修正
  - `$GLOBALS['STDIN']`などグローバル変数の利用を廃止

### テスト確認事項
- モックが適切に動作し、代入した値によってテストが実行される事を確認。

### 備考
- 
