### PR TITLE
feat:ディーラーがバーストした場合の処理を追加

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -41,12 +41,16 @@ class Game
         // プレイヤーの追加カード取得
         $playerResult = $this->gameProcess->addPlayerCard($hands, $this->yourName, $player);
         if ($playerResult === 'あなたの負けです。') {
-            echo "$playerResult";
+            echo "$playerResult" . PHP_EOL;
             return 'ブラックジャックを終了します。' . PHP_EOL;
         }
 
         // ディーラーのカード追加処理
         $dealerScore = $this->gameProcess->addDealerCard($hands);
+        if ($dealerScore === 'あなたの勝ちです。') {
+            echo "$dealerScore" . PHP_EOL;
+            return 'ブラックジャックを終了します。' . PHP_EOL;
+        }
 
         // 勝敗の判定
         $this->gameProcess->judgeWinner($playerResult, $dealerScore, $player->playerName);

--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -60,7 +60,7 @@ class GameProcess
         return $dealerScore;
     }
 
-    public function addDealerCard(array $hands): int
+    public function addDealerCard(array $hands): int|string
     {
         // ディーラーの2枚目のカードを開示
         $dealerScore = $this->pointCalculator->calculatePoint($hands['dealerHand']);
@@ -70,6 +70,10 @@ class GameProcess
 
         $dealerScore = $this->dealerTurn($hands['dealerHand'], $dealerScore);
         echo "ディーラーの現在の得点は{$dealerScore}です。" . PHP_EOL;
+        // バーストしていた場合はゲーム終了
+        if ($dealerScore > 21) {
+            return 'あなたの勝ちです。';
+        }
         echo PHP_EOL;
 
         return $dealerScore;
@@ -81,9 +85,9 @@ class GameProcess
             //操作プレイヤーのスコアを計算
             $playerScore = $this->pointCalculator->calculatePoint($hands['playerHands'][$yourName]);
 
-             // 追加カードによりバーストしていた場合はゲーム終了
+             // バーストしていた場合はゲーム終了
             if ($playerScore > 21) {
-                return 'あなたの負けです。' . PHP_EOL;
+                return 'あなたの負けです。';
             }
 
             echo "あなたの現在の得点は{$playerScore}です。カードを引きますか？（Y/N）" . PHP_EOL;

--- a/src/tests/black_jack/GameProcessTest.php
+++ b/src/tests/black_jack/GameProcessTest.php
@@ -73,10 +73,13 @@ class GameProcessTest extends TestCase
         $dealerMock->method('dealAddCard')->willReturn(['H10']);
 
         $gameProcess = new GameProcess($dealerMock, $deck, $pointCalculator);
-        $dealerScore = $gameProcess->addDealerCard(['dealerHand' => ['D6', 'D5']]);
-
         // 返り値を確認
+        $dealerScore = $gameProcess->addDealerCard(['dealerHand' => ['D6', 'D5']]);
         $this->assertSame(21, $dealerScore);
+        // バーストした場合
+        $dealerScore = $gameProcess->addDealerCard(['dealerHand' => ['D6', 'D7']]);
+        $this->assertSame('あなたの勝ちです。', $dealerScore);
+
     }
 
     public function testAddPlayerCard()

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -48,6 +48,6 @@ class GameTest extends TestCase
         $pointCalculator = new PointCalculator();
         $gameProcess = new GameProcess($dealer, $deck, $pointCalculator, $this->inputHandle);
         $game = new Game($deck, $gameProcess, $dealer, $pointCalculator, ['takuya']);
-        $this->assertSame('ブラックジャックを終了します。', $game->start());
+        $this->assertSame('ブラックジャックを終了します。' .PHP_EOL, $game->start());
     }
 }


### PR DESCRIPTION
### プルリクエスト概要
- ディーラーがバーストした場合、スコアでなくメッセージを返す使用に変更
- 上記に伴い、`addDealerCard()`メソッドの戻り値型を`int`から`int|string`に変更
- Game::start()`で終了メッセージを返す処理を追加

### テスト確認事項
- 正常な処理を確認


### 関連するIssue
Closes #94, #95