### PR TITLE
[#104] ref:出力処理を`PokerOutput`クラスへ分離

### DIFF
--- a/src/lib/black_jack/PokerOutput.php
+++ b/src/lib/black_jack/PokerOutput.php
@@ -10,4 +10,29 @@ class PokerOutput
         echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][0]}です。" . PHP_EOL;
         echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][1]}です。" . PHP_EOL;
     }
+
+    public function displayDealerCard(array $dealerHand): void
+    {
+        echo "ディーラーの引いたカードは{$dealerHand[0]}です。" . PHP_EOL;
+        echo 'ディーラーの引いた2枚目のカードはわかりません。' . PHP_EOL;
+        echo PHP_EOL;
+    }
+
+    public function displayDealerTurn(string $drawnLastCard): void
+    {
+        echo "ディーラーの引いたカードは{$drawnLastCard}です。" . PHP_EOL;
+    }
+
+    public function displayAddDealerCard(array $hands)
+    {
+        echo "ディーラーの引いた2枚目のカードは{$hands['dealerHand'][1]}でした。" . PHP_EOL;
+        // echo "ディーラーの現在の得点は{$dealerScore}です。" . PHP_EOL;
+        // echo PHP_EOL;
+    }
+
+    public function displayDealerScore(int $dealerScore)
+    {
+        echo "ディーラーの現在の得点は{$dealerScore}です。" . PHP_EOL;
+        echo PHP_EOL;
+    }
 }

--- a/src/lib/black_jack/PokerOutput.php
+++ b/src/lib/black_jack/PokerOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BlackJack;
+
+class PokerOutput
+{
+    private const PLAYER_NAME_INDENT = 0;
+    public function displayPlayerCard(array $playerHands, array $playerNames): void
+    {
+        echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][0]}です。" . PHP_EOL;
+        echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][1]}です。" . PHP_EOL;
+    }
+}

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -7,7 +7,7 @@
     </testsuite>
   </testsuites>
 
-   <source>
+  <source>
         <deprecationTrigger>
         </deprecationTrigger>
     </source>

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -4,11 +4,12 @@ namespace BlackJack\Tests;
 
 use PHPUnit\Framework\TestCase;
 use BlackJack\Card;
+use BlackJack\Dealer;
 use BlackJack\Deck;
 use BlackJack\Game;
-use BlackJack\Dealer;
 use BlackJack\GameProcess;
 use BlackJack\PointCalculator;
+use BlackJack\PokerOutput;
 
 
 class GameTest extends TestCase
@@ -37,10 +38,11 @@ class GameTest extends TestCase
         rewind($this->inputHandle); //ストリームポインタをリセット
 
         $card = new Card();
-        $deck = new Deck($card);
         $dealer = new Dealer();
+        $deck = new Deck($card);
         $pointCalculator = new PointCalculator();
-        $gameProcess = new GameProcess($dealer, $deck, $pointCalculator, $this->inputHandle);
+        $pokerOutput = new PokerOutput();
+        $gameProcess = new GameProcess($dealer, $deck, $pointCalculator, $pokerOutput, $this->inputHandle);
         $game = new Game($deck, $gameProcess, $dealer, $pointCalculator, ['takuya']);
         $this->assertSame('ブラックジャックを終了します。' .PHP_EOL, $game->start());
     }

--- a/src/tests/black_jack/PokerOutputTest.php
+++ b/src/tests/black_jack/PokerOutputTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BlackJack\Tests;
+
+use PHPUnit\Framework\TestCase;
+use BlackJack\PokerOutput;
+
+class PokerOutputTest extends TestCase
+{
+    public function testDisplayPlayerCard()
+    {
+        $this->expectOutputString(
+            "あなたの引いたカードは0です。" . PHP_EOL .
+            "あなたの引いたカードは1です。" . PHP_EOL
+        );
+        $pokerOutput = new PokerOutput();
+        $pokerOutput->displayPlayerCard(['takuya' => [0, 1]], ['takuya']);
+    }
+}

--- a/src/tests/black_jack/PokerOutputTest.php
+++ b/src/tests/black_jack/PokerOutputTest.php
@@ -7,6 +7,14 @@ use BlackJack\PokerOutput;
 
 class PokerOutputTest extends TestCase
 {
+    private $pokerOutput;
+    public function setUp(): void
+    {
+        // TestCaseのメソッド呼出し
+        parent::setUp();
+        // デフォルトモック値を設定
+        $this->pokerOutput = new PokerOutput();
+    }
     public function testDisplayPlayerCard()
     {
         $this->expectOutputString(
@@ -16,4 +24,44 @@ class PokerOutputTest extends TestCase
         $pokerOutput = new PokerOutput();
         $pokerOutput->displayPlayerCard(['takuya' => [0, 1]], ['takuya']);
     }
+
+    public function testDisplayDealerCard()
+    {
+        $this->expectOutputString(
+            "ディーラーの引いたカードは0です。" . PHP_EOL .
+            "ディーラーの引いた2枚目のカードはわかりません。" . PHP_EOL . PHP_EOL
+        );
+        $pokerOutput = new PokerOutput();
+        $pokerOutput->displayDealerCard([0, 1]);
+    }
+
+    public function testDisplayDealerTurn()
+    {
+        $this->expectOutputString(
+            "ディーラーの引いたカードはH3です。" . PHP_EOL
+        );
+        $this->pokerOutput->displayDealerTurn('H3');
+    }
+
+    public function testDisplayAddDealerCard()
+    {
+        $this->expectOutputString(
+            "ディーラーの引いた2枚目のカードはH2でした。" . PHP_EOL
+            // "ディーラーの現在の得点は10です。" . PHP_EOL .
+            // PHP_EOL
+        );
+        $this->pokerOutput->displayAddDealerCard(['dealerHand' => ['H1', 'H2']]);
+    }
+
+    public function testDisplayDealerScore()
+    {
+        $this->expectOutputString(
+            "ディーラーの現在の得点は10です。" . PHP_EOL .
+            PHP_EOL
+        );
+        $this->pokerOutput->displayDealerScore(10);
+    }
+
+
+
 }


### PR DESCRIPTION
### プルリクエスト概要
- 出力処理を`PokerOutput`クラスへ分離し、専用クラスで管理することで役割を明確化させました。

### 変更内容
- 単一責任の原則に従い、`GameProcess`内での出力を`PokerOutput`へ分離
- `PokerOutoput`クラスで、出力内容に応じたメソッドを実装

### テスト確認事項
- テストケースが正常に動作することを確認

### 備考
- 
