### PR TITLE
refactor:出力処理を`PokerOutput`クラスへ完全分離

### DIFF
--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -63,10 +63,9 @@ class GameProcess
         $this->pokerOutput->displayDealerScore($dealerScore);
         // バーストしていた場合はゲーム終了
         if ($dealerScore > 21) {
-            return 'あなたの勝ちです。';
+            return $this->pokerOutput->displayPlayerWinMessage();
         }
         echo PHP_EOL;
-
         return $dealerScore;
     }
 
@@ -78,10 +77,12 @@ class GameProcess
 
              // バーストしていた場合はゲーム終了
             if ($playerScore > 21) {
-                return 'あなたの負けです。';
+                return $this->pokerOutput->displayPlayerLoseMessage();
             }
 
-            echo "あなたの現在の得点は{$playerScore}です。カードを引きますか？（Y/N）" . PHP_EOL;
+            // 現在のスコアを出力
+            $this->pokerOutput->displayPlayerScore($playerScore);
+            // ユーザー入力を変数へ代入
             $input = trim(fgets($this->inputHandle));
 
             // 追加のカードを引く場合
@@ -94,7 +95,9 @@ class GameProcess
                 );
                 // 手札の最後の値を取得し、値＝追加カードをユーザーへ表示
                 $drawnLastCard = end($hands['playerHands'][$yourName]);
-                echo "あなたの引いたカードは{$drawnLastCard}です。" . PHP_EOL;
+
+                // 現在のスコアを出力
+                $this->pokerOutput->displayAddPlayerCard($drawnLastCard);
                 continue;
             }
             return $playerScore;
@@ -109,10 +112,6 @@ class GameProcess
         }
 
         // 勝者名を出力
-        echo "あなたの得点は{$playerScore}です。" . PHP_EOL;
-        echo "ディーラーの得点は{$dealerScore}です。" . PHP_EOL;
-        echo PHP_EOL;
-        echo "{$winner}の勝ちです！" . PHP_EOL;
-        return $winner;
+        return $this->pokerOutput->displayGameResult($playerScore, $dealerScore, $winner);
     }
 }

--- a/src/lib/black_jack/PokerOutput.php
+++ b/src/lib/black_jack/PokerOutput.php
@@ -23,16 +23,43 @@ class PokerOutput
         echo "ディーラーの引いたカードは{$drawnLastCard}です。" . PHP_EOL;
     }
 
-    public function displayAddDealerCard(array $hands)
+    public function displayAddDealerCard(array $hands): void
     {
         echo "ディーラーの引いた2枚目のカードは{$hands['dealerHand'][1]}でした。" . PHP_EOL;
-        // echo "ディーラーの現在の得点は{$dealerScore}です。" . PHP_EOL;
-        // echo PHP_EOL;
     }
 
-    public function displayDealerScore(int $dealerScore)
+    public function displayDealerScore(int $dealerScore): void
     {
         echo "ディーラーの現在の得点は{$dealerScore}です。" . PHP_EOL;
         echo PHP_EOL;
+    }
+
+    public function displayPlayerWinMessage(): string
+    {
+        return "あなたの勝ちです。";
+    }
+
+    public function displayPlayerLoseMessage(): string
+    {
+        return "あなたの負けです。";
+    }
+
+    public function displayPlayerScore(int $playerScore): void
+    {
+        echo "あなたの現在の得点は{$playerScore}です。カードを引きますか？（Y/N）" . PHP_EOL;
+    }
+
+    public function displayAddPlayerCard(string $drawnLastCard): void
+    {
+        echo "あなたの引いたカードは{$drawnLastCard}です。" . PHP_EOL;
+    }
+
+    public function displayGameResult(int $playerScore, int $dealerScore, string $winner): string
+    {
+        echo "あなたの得点は{$playerScore}です。" . PHP_EOL;
+        echo "ディーラーの得点は{$dealerScore}です。" . PHP_EOL;
+        echo PHP_EOL;
+        echo "{$winner}の勝ちです！" . PHP_EOL;
+        return $winner;
     }
 }

--- a/src/lib/black_jack/StartGame.php
+++ b/src/lib/black_jack/StartGame.php
@@ -2,17 +2,20 @@
 
 namespace BlackJack;
 
+require 'vendor/autoload.php';
 use BlackJack\Card;
 use BlackJack\Deck;
 use BlackJack\Dealer;
 use BlackJack\Game;
 use BlackJack\GameProcess;
+use BlackJack\PokerOutput;
 use BlackJack\PointCalculator;
 
 $card = new Card();
 $deckInstance = new Deck($card);
 $dealer = new Dealer();
+$pokerOutput = new PokerOutput;
 $pointCalculator = new PointCalculator();
-$gameProcess = new GameProcess($dealer, $deckInstance, $pointCalculator);
+$gameProcess = new GameProcess($dealer, $deckInstance, $pointCalculator, $pokerOutput);
 $game = new Game($deckInstance, $gameProcess, $dealer, $pointCalculator, ['takuya']);
 echo $game->start();

--- a/src/tests/black_jack/PokerOutputTest.php
+++ b/src/tests/black_jack/PokerOutputTest.php
@@ -62,6 +62,38 @@ class PokerOutputTest extends TestCase
         $this->pokerOutput->displayDealerScore(10);
     }
 
+    public function testDisplayPlayerWinMessage()
+    {
+        $message = $this->pokerOutput->DisplayPlayerWinMessage();
+        $this->assertSame('あなたの勝ちです。', $message);
+    }
+
+    public function testDisplayPlayerLoseMessage()
+    {
+        $message = $this->pokerOutput->displayPlayerLoseMessage();
+        $this->assertSame('あなたの負けです。', $message);
+    }
+
+    public function testDisplayPlayerScore()
+    {
+        $this->expectOutputString(
+            "あなたの現在の得点は10です。カードを引きますか？（Y/N）" . PHP_EOL
+        );
+        $this->pokerOutput->displayPlayerScore(10);
+    }
+
+    public function testDisplayAddPlayerCard()
+    {
+        $this->expectOutputString(
+            "あなたの引いたカードはH1です。" . PHP_EOL
+        );
+        $this->pokerOutput->displayAddPlayerCard('H1');
+    }
 
 
+    public function testDisplayGameResult()
+    {
+        $winner = $this->pokerOutput->displayGameResult(21, 18, 'takuya');
+        $this->assertSame('takuya', $winner);
+    }
 }


### PR DESCRIPTION
### プルリクエスト概要
- 単一責任の原則に従い、`GameProcess`内での出力を分離。
- `PokerOutoput`クラスに出力専用メソッドを実装し、出力処理を統一。

### 変更内容
- `GameProcess`クラスの出力処理を`PokerOuでtput`クラスへ移動
- `GameProcess`クラスのコンストラクタで`PokerOutput`インスタンスを受け取るよう変更

### テスト確認事項
- テストコードの正常な処理を確認 

### 備考

Close #102 
