### PR TITLE
feat:Aの手札に対するスコア換算処理を変更

### DIFF
--- a/src/lib/black_jack/PointCalculator.php
+++ b/src/lib/black_jack/PointCalculator.php
@@ -6,20 +6,32 @@ class PointCalculator
 {
     public function calculatePoint(array $hand): int
     {
-        // 手札カードをrank化。スートを除去により。
+        // 手札カードのrankを抽出するため、スートを除去。
         $ranks = [];
+        $score = 0;
         foreach ($hand as $card) {
             $rank = substr($card, 1);
 
-            // rankがJ,Q,K,Aの場合に'10'に変換
-            $aceAndFaceCards = ['J', 'Q', 'K', 'A'];
+            // rankがJ,Q,Kの場合に'10'に変換
+            $aceAndFaceCards = ['J', 'Q', 'K'];
             if (in_array($rank, $aceAndFaceCards)) {
                 $rank = 10;
             }
+            // rankがAの場合、スコアに応じてAを変換
+            if (str_contains($rank, 'A')) {
+                switch ($score) {
+                    case $score <= 11; //11以下の場合、10を追加
+                        $rank = 10;
+                        break;
+                    case $score >= 12; //12以上の場合、1を追加
+                        $rank = 1;
+                        break;
+                }
+            }
             $ranks[] = (int)$rank;
+            // 手札スコアを計算するため、$ranksを合算。
+            $score = array_sum($ranks);
         }
-        // 手札スコアを計算。rankを合算して。
-        $score = array_sum($ranks);
         // 出力
         return $score;
     }

--- a/src/lib/black_jack/PointCalculator.php
+++ b/src/lib/black_jack/PointCalculator.php
@@ -4,29 +4,26 @@ namespace BlackJack;
 
 class PointCalculator
 {
+    const FACE_CARD_VALUE = 10;
+    const ACE_HIGH_VALUE = 10;
+    const ACE_LOW_VALUE = 1;
+
     public function calculatePoint(array $hand): int
     {
-        // 手札カードのrankを抽出するため、スートを除去。
         $ranks = [];
         $score = 0;
+        // 手札カードのrankを抽出するため、スートを除去。
         foreach ($hand as $card) {
             $rank = substr($card, 1);
 
-            // rankがJ,Q,Kの場合に'10'に変換
+            // rankがJ,Q,Kの場合に10を代入
             $aceAndFaceCards = ['J', 'Q', 'K'];
             if (in_array($rank, $aceAndFaceCards)) {
-                $rank = 10;
+                $rank = self::FACE_CARD_VALUE;
             }
             // rankがAの場合、スコアに応じてAを変換
             if (str_contains($rank, 'A')) {
-                switch ($score) {
-                    case $score <= 11; //11以下の場合、10を追加
-                        $rank = 10;
-                        break;
-                    case $score >= 12; //12以上の場合、1を追加
-                        $rank = 1;
-                        break;
-                }
+                $rank = ($score <= 11) ? self::ACE_HIGH_VALUE : self::ACE_LOW_VALUE;
             }
             $ranks[] = (int)$rank;
             // 手札スコアを計算するため、$ranksを合算。

--- a/src/tests/black_jack/PointCalculatorTest.php
+++ b/src/tests/black_jack/PointCalculatorTest.php
@@ -15,9 +15,9 @@ class PointCalculatorTest extends TestCase
         $point = $pointCalculator->calculatePoint(['HQ', 'DK', 'K1']);
         $this->assertSame(21, $point);
         $point = $pointCalculator->calculatePoint(['HQ', 'DK', 'KA']);
-        $this->assertSame(30, $point);
+        $this->assertSame(21, $point);
         $point = $pointCalculator->calculatePoint(['SJ', 'KK', 'SA']);
-        $this->assertSame(30, $point);
+        $this->assertSame(21, $point);
         $point = $pointCalculator->calculatePoint(['S4', 'KA', 'S1']);
         $this->assertSame(15, $point);
     }


### PR DESCRIPTION
### プルリクエスト概要
- ルール変更に対応し、スコアに応じて1または11を加算する処理に変更。

### 変更内容
- `swich`文を使用し、スコアの数値に応じて条件分岐を実装。

### テスト確認事項
- スコアに応じてAが適切に変換され、正常に動作することを確認。

### 備考
- 
