### PR TITLE
Ref:`Dealer`クラスにおける初回カード取得処理を整理

### DIFF
--- a/src/lib/black_jack/Dealer.php
+++ b/src/lib/black_jack/Dealer.php
@@ -11,17 +11,16 @@ class Dealer
 
     public array $dealerCard = [];
 
-    public function dealStartHands(Deck $deck, array $playerNames): array
+    public function dealStartHands(Deck $deck): array
     {
-        $playerHands = $deck->startHands($playerNames);
-        return $playerHands;
+        return $deck->drawCard(self::FIRST_CARD_NUMBER);
     }
-
-    public function makeDealerHand(Deck $deck): array
-    {
-        $dealerHand = $deck->drawCard(self::FIRST_CARD_NUMBER);
-        return $dealerHand;
-    }
+    // TODO dealStartHands（）に統一かのうでは？
+    // public function makeDealerHand(Deck $deck): array
+    // {
+    //     $dealerHand = $deck->drawCard(self::FIRST_CARD_NUMBER);
+    //     return $dealerHand;
+    // }
 
     public function dealAddCard(Deck $deck): array
     {

--- a/src/lib/black_jack/Deck.php
+++ b/src/lib/black_jack/Deck.php
@@ -23,13 +23,10 @@ class Deck
         return $this->drawnCard;
     }
 
-    public function startHands(array $playerNames): array
-    {
-        $playerHands = [];
-        foreach ($playerNames as $playerName) {
-            $this->drawCard(2);
-            $playerHands[$playerName] = $this->drawnCard;
-        }
-        return $playerHands;
-    }
+    // // TODO 不要では？ここでスタート手札を作成するのでなく、playerのgetHand()で初回手札作成。その為にdealerとdeckにカードを引かせる　そうすると、この関数が不要だし、もともとこの関数までプレイヤー名を渡し渡ししてここで初回カードを組んで返して返してとしていた　渡すのと返すのが無駄。また、deckはカードを引く処理のみに単一責任になる
+    // public function startHands(): array
+    // {
+    //         $this->drawCard(2);
+    //         return $this->drawnCard;
+    // }
 }

--- a/src/tests/black_jack/DealerTest.php
+++ b/src/tests/black_jack/DealerTest.php
@@ -11,31 +11,29 @@ class DealerTest extends TestCase
 {
     public function testDealStartCard()
     {
-        $deck = new Deck(new Card());
-        $dealer = new Dealer();
-        $playerNames = ['takuya'];
-        $playerHands = $dealer->dealStartHands($deck, $playerNames);
+        $expectedCards = ['K1', 'D1'];
+        $deckMock = $this->createMock(Deck::class);
+        $deckMock->expects($this->once())
+                ->method('drawCard')
+                ->with(2)
+                ->willReturn($expectedCards);
 
-        // プレイヤーの人数分の手札の有無
-        $this->assertSame(count($playerNames), count($playerHands));
-        // プレイヤーが2人の場合
-        $playerNames = ['takuya', 'akemi'];
-        $playerHands = $dealer->dealStartHands($deck, $playerNames);
-        $this->assertSame(count($playerNames), count($playerHands));
-        // プレイヤーが3人の場合
-        $playerNames = ['takuya', 'akemi', 'kawasaki'];
-        $playerHands = $dealer->dealStartHands($deck, $playerNames);
-        $this->assertSame(count($playerNames), count($playerHands));
-    }
-
-    public function testMakeDealerHand()
-    {
-        $deck = new Deck(new Card());
         $dealer = new Dealer();
+        $result = $dealer->dealStartHands($deckMock);
 
         // カードの枚数を確認
-        $this->assertSame(2, count($dealer->makeDealerHand($deck)));
+        $this->assertSame($expectedCards, $result);
     }
+
+    // TODO 不要な場合は削除
+    // public function testMakeDealerHand()
+    // {
+    //     $deck = new Deck(new Card());
+    //     $dealer = new Dealer();
+
+    //     // カードの枚数を確認
+    //     $this->assertSame(2, count($dealer->makeDealerHand($deck)));
+    // }
 
     public function testDealAddCard()
     {

--- a/src/tests/black_jack/DeckTest.php
+++ b/src/tests/black_jack/DeckTest.php
@@ -31,13 +31,14 @@ class DeckTest extends TestCase
         $this->assertSame(false, in_array($drawnCard[1], $deck->cardDeck));
     }
 
-    public function testStartHands()
-    {
-        $deck = new Deck(new Card());
-        $playerHands = $deck->startHands(['takuya', 'takashi']);
+    // TODO:不要な場合、削除
+    // public function testStartHands()
+    // {
+    //     $deck = new Deck(new Card());
+    //     $playerHands = $deck->startHands(['takuya', 'takashi']);
 
-        // 手札枚数の確認
-        $this->assertSame(2, count($playerHands['takuya']));
-        $this->assertSame(2, count($playerHands['takashi']));
-    }
+    //     // 手札枚数の確認
+    //     $this->assertSame(2, count($playerHands['takuya']));
+    //     $this->assertSame(2, count($playerHands['takashi']));
+    // }
 }


### PR DESCRIPTION
### 概要
-  処理内容が重複しているため、`Dealer`クラスの`makeDealerHands`メソッドを削除、初回手札作成処理を`dealStartHands`メソッドに統一

### 変更内容
- `Dealer` クラス
  - `makeDealerHands` メソッドを削除し、`dealStartHands` メソッドに処理を統一
  - 初回手札作成の処理フローを整理
  
- `Deck`クラス
  - `startHands`メソッドを削除し、カードを引く処理を`drawCard`メソッドに統一
  - 単一責任の原則に基づき、カードを引く処理に集中
  - 手札を作成していた`startHands`メソッドを削除

### テスト確認事項
- `DealerTest``DeckTest`において、正常に動作することを確認

### 備考
- 
