### PR TITLE
feat:複数プレイヤー対応のため、出力内容にプレイヤー名を追加

### DIFF
--- a/src/lib/black_jack/PokerOutput.php
+++ b/src/lib/black_jack/PokerOutput.php
@@ -4,11 +4,12 @@ namespace BlackJack;
 
 class PokerOutput
 {
-    private const PLAYER_NAME_INDENT = 0;
-    public function displayPlayerCard(array $playerHands, array $playerNames): void
+    public function displayPlayerCard(array $playerHands): void
     {
-        echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][0]}です。" . PHP_EOL;
-        echo "あなたの引いたカードは{$playerHands[$playerNames[self::PLAYER_NAME_INDENT]][1]}です。" . PHP_EOL;
+        foreach ($playerHands as $playerName => $playerHand) {
+            echo "{$playerName}の引いた1枚目のカードは{$playerHand[0]}です。" . PHP_EOL;
+            echo "{$playerName}の引いた2枚目のカードは{$playerHand[1]}です。" . PHP_EOL;
+        }
     }
 
     public function displayDealerCard(array $dealerHand): void

--- a/src/tests/black_jack/PokerOutputTest.php
+++ b/src/tests/black_jack/PokerOutputTest.php
@@ -18,8 +18,8 @@ class PokerOutputTest extends TestCase
     public function testDisplayPlayerCard()
     {
         $this->expectOutputString(
-            "あなたの引いたカードは0です。" . PHP_EOL .
-            "あなたの引いたカードは1です。" . PHP_EOL
+            "takuyaの引いた1枚目のカードは0です。" . PHP_EOL .
+            "takuyaの引いた2枚目のカードは1です。" . PHP_EOL
         );
         $pokerOutput = new PokerOutput();
         $pokerOutput->displayPlayerCard(['takuya' => [0, 1]], ['takuya']);


### PR DESCRIPTION
### 概要
- 出力メッセージで各プレイヤー名を表示し、複数プレイヤーによるゲームに対応

### テスト確認事項
- 正常に動作することを確認。
