### PR TITLE
ディーラーバースト時の処理を変更

### DIFF
--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -37,29 +37,30 @@ class Game
 
         // プレイヤーの追加カード取得。バーストの場合は文字列の為、変数名をScoreでなくResultに設定
         $playerResult = $this->gameProcess->addYourTurn($hands['playerHands'][$yourName],   $playerInstances[$yourName]);
-        if ($this->isGameOrver($playerResult)) {
+        if ($this->isGameOver($playerResult)) {
             return $this->yourLose($playerResult);
         }
 
         // ディーラーのカード追加処理
         $dealerScore = $this->gameProcess->addDealerCard($hands);
-        $this->gameProcess->processDealerBurnOut($dealerScore);
+        // ディーラーがバーンアウトしてないかチェック
+        $isBurnOut = $this->gameProcess->processDealerBurnOut($dealerScore);
+
+        if ($isBurnOut) {
+            $this->pokerOutPut->displayGameEndMessage();
+            exit;
+        }
         // 現在のスコアを出力
         $this->pokerOutPut->displayDealerScore($dealerScore);
         echo PHP_EOL;
         ;
-
-        if ($dealerScore === 'あなたの勝ちです。') {
-            echo "$dealerScore" . PHP_EOL;
-            return 'ブラックジャックを終了します。' . PHP_EOL;
-        }
 
         // 勝敗の判定
         $this->gameProcess->judgeWinner($playerResult, $dealerScore, $this->playerNames);
         return 'ブラックジャックを終了します。' . PHP_EOL;
         }
 
-        private function isGameOrver(string | int $playerResult): bool
+        private function isGameOver(string | int $playerResult): bool
         {
             if($playerResult == 'あなたの負けです。') {
                 return true;

--- a/src/lib/black_jack/Game.php
+++ b/src/lib/black_jack/Game.php
@@ -5,6 +5,7 @@ namespace BlackJack;
 use BlackJack\Deck;
 use BlackJack\Dealer;
 use BlackJack\PointCalculator;
+use BlackJack\PokerOutput;
 use BlackJack\GameProcess;
 
 class Game
@@ -15,6 +16,7 @@ class Game
         public Deck $deck,
         public GameProcess $gameProcess,
         public PointCalculator $pointCalculator,
+        public PokerOutput $pokerOutPut,
         public PlayerFactory $playerFactory,
         public array $playerNames
     ) {
@@ -41,15 +43,12 @@ class Game
 
         // ディーラーのカード追加処理
         $dealerScore = $this->gameProcess->addDealerCard($hands);
-
-        // バースト判定　バーストであれば、trueを受け取る
-        $isBurnOut = $this->gameProcess->checkBurnOut($dealerScore);
-        if($isBurnOut) {
-             // 現在のスコアを出力
-        $this->pokerOutput->displayDealerScore($dealerScore);
+        $this->gameProcess->processDealerBurnOut($dealerScore);
+        // 現在のスコアを出力
+        $this->pokerOutPut->displayDealerScore($dealerScore);
         echo PHP_EOL;
         ;
-        }
+
         if ($dealerScore === 'あなたの勝ちです。') {
             echo "$dealerScore" . PHP_EOL;
             return 'ブラックジャックを終了します。' . PHP_EOL;

--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -43,10 +43,21 @@ class GameProcess
     // バースト判定
     public function checkBurnOut(int $score): bool {
         if ($score > 21) {
-            $this->pokerOutput->displayDealerBurstMessage();
             return true;
         }
         return false;
+    }
+
+    // バースト時の処理
+    public function processDealerBurnOut(int $dealerScore): void
+    {
+        // バースト判定　バーストであれば、trueを受け取る
+        $isBurnOut = $this->checkBurnOut($dealerScore);
+        if($isBurnOut) {
+            $this->pokerOutput->displayDealerBurstMessage();
+            $this->pokerOutput->displayGameEndMessage();
+            return;
+        }
     }
 
     // ディーラーのカード取得

--- a/src/lib/black_jack/GameProcess.php
+++ b/src/lib/black_jack/GameProcess.php
@@ -49,15 +49,15 @@ class GameProcess
     }
 
     // バースト時の処理
-    public function processDealerBurnOut(int $dealerScore): void
+    public function processDealerBurnOut(int $dealerScore): bool
     {
         // バースト判定　バーストであれば、trueを受け取る
         $isBurnOut = $this->checkBurnOut($dealerScore);
         if($isBurnOut) {
             $this->pokerOutput->displayDealerBurstMessage();
-            $this->pokerOutput->displayGameEndMessage();
-            return;
+            return true;
         }
+        return false;
     }
 
     // ディーラーのカード取得

--- a/src/lib/black_jack/PokerOutput.php
+++ b/src/lib/black_jack/PokerOutput.php
@@ -42,12 +42,18 @@ class PokerOutput
 
     public function displayDealerBurstMessage(): void
     {
-        echo "ディーラーがバーストしました。あなたの勝ちです。";
+        echo "ディーラーがバーストしました。あなたの勝ちです。" . PHP_EOL;
     }
+
 
     public function displayYourLoseMessage(): void
     {
         echo "あなたの負けです。";
+    }
+
+    public function displayGameEndMessage(): void
+    {
+        echo "ゲームを終了します。" . PHP_EOL;
     }
 
     public function displayPlayerScore(int $playerScore): void

--- a/src/tests/black_jack/GameTest.php
+++ b/src/tests/black_jack/GameTest.php
@@ -43,7 +43,7 @@ class GameTest extends TestCase
         $pokerOutput = new PokerOutput();
         $playerFactory = new PlayerFactory($dealer, $deck, ['takuya', 'toki', 'asuka']);
         $gameProcess = new GameProcess($dealer, $deck, $pointCalculator, $pokerOutput, $this->inputHandle);
-        $game = new Game($dealer, $deck, $gameProcess, $pointCalculator, $playerFactory, ['takuya', 'toki', 'asuka']);
+        $game = new Game($dealer, $deck, $gameProcess, $pointCalculator, $pokerOutput, $playerFactory, ['takuya', 'toki', 'asuka']);
         $this->assertSame('ブラックジャックを終了します。' .PHP_EOL, $game->start());
     }
 }


### PR DESCRIPTION
### 変更内容
- `displayGameEndMessage`メソッドを追加し、ゲーム終了時のmessage出力をメソッド化
- `processDealerBurnOut`メソッドを作成、ディーラーのバーンアウトに関する処理を集約